### PR TITLE
Add tested DTMF support for Quectel EC20

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,36 @@ In many modules, when AT^DSCI=1 is set, URC for call status indication is genera
 
 Armed with this knowledge and using AT^DSCI=1 as an intialization command, we can now set up the Huawei ^ORIG URC <a href="https://github.com/IchthysMaranatha/asterisk-chan-quectel/blob/b6f6a389f2d8cc0b1ba183f6ebe7f140e03730af/at_response.h#L32">here</a> to handle entire call management (initiatiing, connecting in or out, terminating) through code block <a href="https://github.com/IchthysMaranatha/asterisk-chan-quectel/blob/b6f6a389f2d8cc0b1ba183f6ebe7f140e03730af/at_response.c#L612-L737">here</a> with necessary changes.
 
-Simcom was very tricky to get working as there is no proper call termination URC and its serial audio port also does not play well with the chan_dongle code. But thanks to God, was finally able to get it working. Still remains a hack job as call ids cannot be matched for termination. If your call ids are different from 1,2,3 or 4 for outgoing and incoming calls, you'll need to make changes in this block <a href="https://github.com/IchthysMaranatha/asterisk-chan-quectel/blob/08d3bcad0de21f93eaad9652ccb48ecb9b04a8e6/at_response.c#L105-L143">here</a>
+## Notes
 
-Way forward: This <a href="http://laforge.gnumonks.org/blog/20170902-cellular_modems-voice/">justified rant</a> by a professional in the industry points out that the virtual sound card solution is the way voice should be provided. We can already see that in few modules from Quectel, Telit, u-blox, Sierra Wireless etc. With very few changes in code, non-Quectel modules with USB audio can most probably be accommodated. Please get in touch in the discussions thread on this topic if you have such a module.
+This fork includes compatibility fixes for Quectel EC20 modules, including improved call state handling and QTONEDET based DTMF support for IVR applications.
 
-Those with problems with chan_mobile with certain bluetooth controllers such as the in built Raspberry Pi one may find a solution <a href="https://blog.maplein.com/2021/09/fix-for-audio-issues-with-asterisk-and.html">here</a>
+## Quectel EC20
 
-Thanks be to the Father of Lights from Whom are all good things.
+Tested with:
 
-In these days of great darkness, when truth and justice are outlawed and where believers themselves are greater obstacles than the atheists with their bigotry, hatred, self-righteousness, falsehood and pride you may just find God speaking to you through this random message to Vassula https://ww3.tlig.org/en/the-messages/messages-random/ or a random verse from the bible www.sandersweb.net/bible/verse.php
+- Quectel EC20
+- Asterisk 22
+- FreePBX 17
+- USB Audio Class (UAC)
 
-I do not need donations, but if you wish you could donate to the person I've forked this from. Or if so inclined, you could donate here https://bethmyriam.org/ 
+Additional changes:
+
+- QTONEDET DTMF event support
+- Improved call state processing
+- Better IVR compatibility
 
 Building:
 ----------
-
+    $ apt install -y build-essential autoconf automake libtool pkg-config asterisk22-devel libasound2-dev libsqlite3-dev
     $ ./bootstrap
-    $ ./configure --with-astversion=16.20
+    $ ./configure --with-astversion=22.8.0 DESTDIR=/usr/lib/x86_64-linux-gnu/asterisk/modules
     $ make
     $ make install
     copy quectel.conf to /etc/asterisk Change context and audio serial port as required
 
 If you run a different version of Asterisk, you'll need to update the
-`16.20` as appropriate, obviously.
+`22.8` as appropriate, obviously.
 
 If you did not `make install` Asterisk in the usual location and configure
 cannot find the asterisk header files in `/usr/include/asterisk`, you may

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 Channel driver for Quectel and Simcom modules 
 =================================================
+## Notes
+
+This fork includes compatibility fixes for Quectel EC20 modules, including improved call state handling and QTONEDET based DTMF support for IVR applications.
+
 This should work with Quectel modules such as EC20, EC21, EC25, EG9x and Simcom sim7600 and possibly other models with voice over USB capability. Tested with the EC25-E mini-pcie module and Waveshare sim7600 g-h dongle. If the product page of your Quectel module contains the application note Voice over USB and UAC or Voice over UAC, you should be good to go. Praise God! Have been able to integrate ALSA support for UAC mode, steps to use UAC can be found <a href="https://github.com/IchthysMaranatha/asterisk-chan-quectel/discussions/2">here</a> If using Quectel serial audio port, please ensure gps messages has been turned off with AT+QGPSCFG="outport","none"
 
 Note for Pi users: If using a Pi and especially a device older than Pi4, you will invariably have problems of various kinds if powering the modem using a Pi usb port due to the current limiting circuit (600ma - 1.2A). Even with a Pi 4, you will not be able to stably handle modem devices with a larger power draw (2.1A) than that of the waveshare sim7600 dongle. You will need to provide independent power to the modem without using the Pi usb port which must only be used for data communication. If the modem device is a Pi HAT, you can provide power by stacking and using a beefy power supply. 
@@ -12,9 +16,6 @@ In many modules, when AT^DSCI=1 is set, URC for call status indication is genera
 
 Armed with this knowledge and using AT^DSCI=1 as an intialization command, we can now set up the Huawei ^ORIG URC <a href="https://github.com/IchthysMaranatha/asterisk-chan-quectel/blob/b6f6a389f2d8cc0b1ba183f6ebe7f140e03730af/at_response.h#L32">here</a> to handle entire call management (initiatiing, connecting in or out, terminating) through code block <a href="https://github.com/IchthysMaranatha/asterisk-chan-quectel/blob/b6f6a389f2d8cc0b1ba183f6ebe7f140e03730af/at_response.c#L612-L737">here</a> with necessary changes.
 
-## Notes
-
-This fork includes compatibility fixes for Quectel EC20 modules, including improved call state handling and QTONEDET based DTMF support for IVR applications.
 
 ## Quectel EC20
 

--- a/at_response.c
+++ b/at_response.c
@@ -14,6 +14,9 @@
 
 #include <asterisk/logger.h>			/* ast_debug() */
 #include <asterisk/pbx.h>			/* ast_pbx_start() */
+#include <asterisk/channel.h>
+#include <asterisk/frame.h>
+#include <asterisk/time.h>
 #include <sys/sysinfo.h>
 #include "ast_compat.h"				/* asterisk compatibility fixes */
 
@@ -88,7 +91,102 @@ static void request_clcc(struct pvt* pvt)
 		ast_log(LOG_ERROR, "[%s] Error enqueue List Current Calls request\n", PVT_ID(pvt));
 	}
 }
+static void enable_qtonedet(struct pvt *pvt)
+{
+	static const char cmd_qtonedet[] = "AT+QTONEDET=1\r";
+	static const at_queue_cmd_t cmds[] = {
+		ATQ_CMD_DECLARE_STIT(CMD_USER, cmd_qtonedet, ATQ_CMD_TIMEOUT_MEDIUM, 0),
+	};
 
+	if (at_queue_insert_const(&pvt->sys_chan, cmds, ITEMS_OF(cmds), 1) != 0)
+	{
+		ast_log(LOG_ERROR, "[%s] Error enqueue QTONEDET enable command\n", PVT_ID(pvt));
+	}
+	else
+	{
+		ast_debug(1, "[%s] QTONEDET enable command queued\n", PVT_ID(pvt));
+	}
+}
+static int qtonedet_code_to_digit(int code, char *digit)
+{
+	switch (code)
+	{
+		case 48: *digit = '0'; return 1;
+		case 49: *digit = '1'; return 1;
+		case 50: *digit = '2'; return 1;
+		case 51: *digit = '3'; return 1;
+		case 52: *digit = '4'; return 1;
+		case 53: *digit = '5'; return 1;
+		case 54: *digit = '6'; return 1;
+		case 55: *digit = '7'; return 1;
+		case 56: *digit = '8'; return 1;
+		case 57: *digit = '9'; return 1;
+		case 42: *digit = '*'; return 1;
+		case 35: *digit = '#'; return 1;
+		case 65: *digit = 'A'; return 1;
+		case 66: *digit = 'B'; return 1;
+		case 67: *digit = 'C'; return 1;
+		case 68: *digit = 'D'; return 1;
+	}
+
+	return 0;
+}
+
+static int at_response_qtonedet(struct pvt *pvt, const char *str)
+{
+	int code;
+	char digit;
+	struct cpvt *cpvt;
+	struct ast_frame f;
+	struct timeval now;
+
+	if (sscanf(str, "+QTONEDET: %d", &code) != 1)
+	{
+		ast_debug(1, "[%s] Cannot parse QTONEDET URC '%s'\n", PVT_ID(pvt), str);
+		return 0;
+	}
+
+	if (!qtonedet_code_to_digit(code, &digit))
+	{
+		ast_debug(1, "[%s] QTONEDET status/result code %d ignored\n", PVT_ID(pvt), code);
+		return 0;
+	}
+
+	cpvt = active_cpvt(pvt);
+	if (!cpvt || !cpvt->channel)
+	{
+		ast_debug(1, "[%s] QTONEDET '%c' received but no active channel\n", PVT_ID(pvt), digit);
+		return 0;
+	}
+
+	now = ast_tvnow();
+	if (digit == pvt->dtmf_digit &&
+		!ast_tvzero(pvt->dtmf_end_time) &&
+		ast_tvdiff_ms(now, pvt->dtmf_end_time) < CONF_SHARED(pvt, mindtmfinterval))
+	{
+		ast_debug(1, "[%s] QTONEDET '%c' ignored min interval %d > %ld\n",
+			PVT_ID(pvt), digit, CONF_SHARED(pvt, mindtmfinterval),
+			(long) ast_tvdiff_ms(now, pvt->dtmf_end_time));
+		return 0;
+	}
+
+	memset(&f, 0, sizeof(f));
+	f.frametype = AST_FRAME_DTMF_BEGIN;
+	f.subclass.integer = digit;
+	ast_queue_frame(cpvt->channel, &f);
+
+	memset(&f, 0, sizeof(f));
+	f.frametype = AST_FRAME_DTMF_END;
+	f.subclass.integer = digit;
+	f.len = 100;
+	ast_queue_frame(cpvt->channel, &f);
+
+	pvt->dtmf_digit = digit;
+	pvt->dtmf_end_time = now;
+
+	ast_debug(1, "[%s] QTONEDET code %d queued as DTMF '%c'\n", PVT_ID(pvt), code, digit);
+	return 0;
+}
 static int at_response_rcend (struct pvt * pvt, const char* str)
 {
 	int call_index = 0;
@@ -278,6 +376,7 @@ static int at_response_ok (struct pvt* pvt, at_res_t res)
 					pvt->initialized = 1;
 					ast_verb (3, "[%s] Quectel initialized and ready\n", PVT_ID(pvt));
 					manager_event_device_status(PVT_ID(pvt), "Initialize");
+					enable_qtonedet(pvt);
 				}
 				break;
 
@@ -312,6 +411,7 @@ static int at_response_ok (struct pvt* pvt, at_res_t res)
 					pvt->initialized = 1;
 					ast_verb (3, "[%s] Quectel initialized and ready\n", PVT_ID(pvt));
 					manager_event_device_status(PVT_ID(pvt), "Initialize");
+					enable_qtonedet(pvt);
 				}
 				break;
 			case CMD_AT_DDSETEX0:
@@ -2194,6 +2294,11 @@ int at_response (struct pvt* pvt, const struct iovec iov[2], int iovcnt, at_res_
 				return -1;
 
 			case RES_UNKNOWN:
+				if (!strncmp(str, "+QTONEDET:", 10))
+				{
+					return at_response_qtonedet(pvt, str);
+				}
+
 				if (ecmd)
 				{
 					switch (ecmd->cmd)


### PR DESCRIPTION
This pull request adds/improves DTMF handling for Quectel EC20 modules.

Tested with a Quectel EC20 modem. During a call, DTMF input can be detected correctly, and dialed digits can be read as expected.

Tested behavior:

```text
- Quectel EC20 module
- Incoming call / active call DTMF detection
- Dialed number keys can be read correctly
```

Please review and let me know if any adjustment is needed for compatibility with other Quectel modules.
